### PR TITLE
Added client type

### DIFF
--- a/src/main/java/com/flipkart/foxtrot/client/ClientType.java
+++ b/src/main/java/com/flipkart/foxtrot/client/ClientType.java
@@ -1,0 +1,11 @@
+package com.flipkart.foxtrot.client;
+
+/**
+ * Created by rishabh.goyal on 27/05/15.
+ */
+public enum ClientType {
+    sync,
+    async,
+    queued_sync,
+    queued_async
+}

--- a/src/main/java/com/flipkart/foxtrot/client/ClientType.java
+++ b/src/main/java/com/flipkart/foxtrot/client/ClientType.java
@@ -6,6 +6,5 @@ package com.flipkart.foxtrot.client;
 public enum ClientType {
     sync,
     async,
-    queued_sync,
-    queued_async
+    queued
 }

--- a/src/main/java/com/flipkart/foxtrot/client/FoxtrotClient.java
+++ b/src/main/java/com/flipkart/foxtrot/client/FoxtrotClient.java
@@ -11,8 +11,9 @@ import com.flipkart.foxtrot.client.serialization.JacksonJsonFoxtrotClusterRespon
 import com.flipkart.foxtrot.client.serialization.JacksonJsonSerializationHandler;
 import com.flipkart.foxtrot.client.util.TypeChecker;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class FoxtrotClient {
@@ -27,16 +28,47 @@ public class FoxtrotClient {
                          MemberSelector memberSelector,
                          EventSerializationHandler serializationHandler) throws Exception {
         this.foxtrotCluster = new FoxtrotCluster(config, memberSelector,
-                                                    JacksonJsonFoxtrotClusterResponseSerializationHandlerImpl.INSTANCE);
-        this.eventSender
-                = Strings.isNullOrEmpty(config.getLocalQueuePath())
-                    ? new HttpAsyncEventSender(config, foxtrotCluster, serializationHandler)
-                    : new QueuedSender(
-                            new HttpSyncEventSender(config, foxtrotCluster, serializationHandler),
-                            serializationHandler,
-                            config.getLocalQueuePath(),
-                            config.getBatchSize(),
-                            config.getRefreshIntervalSecs());
+                JacksonJsonFoxtrotClusterResponseSerializationHandlerImpl.INSTANCE);
+
+        switch (config.getClientType()) {
+            case sync:
+                this.eventSender = new HttpSyncEventSender(config, foxtrotCluster, serializationHandler);
+                break;
+            case async:
+                this.eventSender = new HttpAsyncEventSender(config, foxtrotCluster, serializationHandler);
+                break;
+            case queued_sync:
+                List<String> messages = new ArrayList<>();
+                if (StringUtils.isEmpty(config.getQueuePath())) {
+                    messages.add("Empty Local Queue Path");
+                }
+                if (config.getBatchSize() <= 1) {
+                    messages.add("batchSize must be greater than 1 for queued sender");
+                }
+                if (!messages.isEmpty()) {
+                    throw new Exception(messages.toString());
+                }
+                this.eventSender = new QueuedSender(new HttpSyncEventSender(config, foxtrotCluster, serializationHandler),
+                        serializationHandler,
+                        config.getQueuePath(),
+                        config.getBatchSize()
+                );
+                break;
+            case queued_async:
+                this.eventSender = new QueuedSender(new HttpAsyncEventSender(config, foxtrotCluster, serializationHandler),
+                        serializationHandler,
+                        config.getQueuePath(),
+                        config.getBatchSize()
+                );
+                break;
+            default:
+                throw new Exception(
+                        String.format("Invalid client type : %s allowed_types : %s",
+                                config.getClientType(),
+                                StringUtils.join(ClientType.values(), ",")
+                        )
+                );
+        }
     }
 
     public FoxtrotClient(FoxtrotCluster foxtrotCluster, EventSender eventSender) {

--- a/src/main/java/com/flipkart/foxtrot/client/FoxtrotClient.java
+++ b/src/main/java/com/flipkart/foxtrot/client/FoxtrotClient.java
@@ -37,7 +37,7 @@ public class FoxtrotClient {
             case async:
                 this.eventSender = new HttpAsyncEventSender(config, foxtrotCluster, serializationHandler);
                 break;
-            case queued_sync:
+            case queued:
                 List<String> messages = new ArrayList<>();
                 if (StringUtils.isEmpty(config.getQueuePath())) {
                     messages.add("Empty Local Queue Path");
@@ -49,13 +49,6 @@ public class FoxtrotClient {
                     throw new Exception(messages.toString());
                 }
                 this.eventSender = new QueuedSender(new HttpSyncEventSender(config, foxtrotCluster, serializationHandler),
-                        serializationHandler,
-                        config.getQueuePath(),
-                        config.getBatchSize()
-                );
-                break;
-            case queued_async:
-                this.eventSender = new QueuedSender(new HttpAsyncEventSender(config, foxtrotCluster, serializationHandler),
                         serializationHandler,
                         config.getQueuePath(),
                         config.getBatchSize()

--- a/src/main/java/com/flipkart/foxtrot/client/FoxtrotClientConfig.java
+++ b/src/main/java/com/flipkart/foxtrot/client/FoxtrotClientConfig.java
@@ -36,15 +36,15 @@ public class FoxtrotClientConfig {
     private ClientType clientType = ClientType.async;
 
     /**
-     * Used if clientType is {@link com.flipkart.foxtrot.client.ClientType#queued_sync}
-     * or {@link com.flipkart.foxtrot.client.ClientType#queued_async}
+     * Used if clientType is {@link com.flipkart.foxtrot.client.ClientType#queued}
+     * or {@link com.flipkart.foxtrot.client.ClientType#queued}
      * Temporary file system path where events will be saved before ingestion.
      */
     private String queuePath;
 
     /**
-     * Used if clientType is {@link com.flipkart.foxtrot.client.ClientType#queued_sync}
-     * or {@link com.flipkart.foxtrot.client.ClientType#queued_async}
+     * Used if clientType is {@link com.flipkart.foxtrot.client.ClientType#queued}
+     * or {@link com.flipkart.foxtrot.client.ClientType#queued}
      * Number of messages to push per batch.
      * (Default: 200)
      */

--- a/src/main/java/com/flipkart/foxtrot/client/FoxtrotClientConfig.java
+++ b/src/main/java/com/flipkart/foxtrot/client/FoxtrotClientConfig.java
@@ -30,16 +30,25 @@ public class FoxtrotClientConfig {
     private int refreshIntervalSecs = 1;
 
     /**
-     * If {@link com.flipkart.foxtrot.client.senders.QueuedSender} is used, the number of messages to push per batch.
+     * Type of client which will init. Can be any of {@link com.flipkart.foxtrot.client.ClientType}
+     * Default value is {@link com.flipkart.foxtrot.client.ClientType#async}
+     */
+    private ClientType clientType = ClientType.async;
+
+    /**
+     * Used if clientType is {@link com.flipkart.foxtrot.client.ClientType#queued_sync}
+     * or {@link com.flipkart.foxtrot.client.ClientType#queued_async}
+     * Temporary file system path where events will be saved before ingestion.
+     */
+    private String queuePath;
+
+    /**
+     * Used if clientType is {@link com.flipkart.foxtrot.client.ClientType#queued_sync}
+     * or {@link com.flipkart.foxtrot.client.ClientType#queued_async}
+     * Number of messages to push per batch.
      * (Default: 200)
      */
     private int batchSize = 200;
-
-    /**
-     * The file system path where the {@link com.flipkart.foxtrot.client.senders.QueuedSender} will save the events.
-     * NOTE: If this is not provided an instance of {@link com.flipkart.foxtrot.client.senders.HttpAsyncEventSender} is used.
-     */
-    private String localQueuePath;
 
     public FoxtrotClientConfig() {
     }
@@ -48,8 +57,8 @@ public class FoxtrotClientConfig {
         return table;
     }
 
-    public void setTable(String appName) {
-        this.table = appName;
+    public void setTable(String table) {
+        this.table = table;
     }
 
     public String getHost() {
@@ -84,12 +93,12 @@ public class FoxtrotClientConfig {
         this.refreshIntervalSecs = refreshIntervalSecs;
     }
 
-    public String getLocalQueuePath() {
-        return localQueuePath;
+    public ClientType getClientType() {
+        return clientType;
     }
 
-    public void setLocalQueuePath(String localQueuePath) {
-        this.localQueuePath = localQueuePath;
+    public void setClientType(ClientType clientType) {
+        this.clientType = clientType;
     }
 
     public int getBatchSize() {
@@ -98,5 +107,13 @@ public class FoxtrotClientConfig {
 
     public void setBatchSize(int batchSize) {
         this.batchSize = batchSize;
+    }
+
+    public String getQueuePath() {
+        return queuePath;
+    }
+
+    public void setQueuePath(String queuePath) {
+        this.queuePath = queuePath;
     }
 }

--- a/src/main/java/com/flipkart/foxtrot/client/senders/QueuedSender.java
+++ b/src/main/java/com/flipkart/foxtrot/client/senders/QueuedSender.java
@@ -42,17 +42,15 @@ public class QueuedSender extends EventSender {
     /**
      * Instantiates a new Queued sender.
      *
-     * @param eventSender              Set a sender like {@link com.flipkart.foxtrot.client.senders.HttpSyncEventSender}.
-     * @param path                     The path to the queue file.
-     * @param batchSize                The size of the batch to be sent per API call.
-     * @param numSecondsBetweenRefresh the num seconds between refresh
+     * @param eventSender Set a sender like {@link com.flipkart.foxtrot.client.senders.HttpSyncEventSender}.
+     * @param path        The path to the queue file.
+     * @param batchSize   The size of the batch to be sent per API call.
      * @throws Exception the exception
      */
     public QueuedSender(EventSender eventSender,
                         EventSerializationHandler serializationHandler,
                         final String path,
-                        int batchSize,
-                        int numSecondsBetweenRefresh) throws Exception {
+                        int batchSize) throws Exception {
         super(serializationHandler);
         this.eventSender = eventSender;
         Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwxrwxrwx");
@@ -61,9 +59,8 @@ public class QueuedSender extends EventSender {
         this.messageQueue = new BigQueueImpl(path, "foxtrot-messages");
         this.messageSenderThread = new MessageSenderThread(this, eventSender, messageQueue, getSerializationHandler(), batchSize);
         this.scheduler = Executors.newScheduledThreadPool(2);
-        scheduler.scheduleWithFixedDelay(messageSenderThread, 0,
-                numSecondsBetweenRefresh, TimeUnit.SECONDS);
-        scheduler.scheduleAtFixedRate(new QueueCleaner(messageQueue), 0, 15, TimeUnit.SECONDS);
+        scheduler.scheduleWithFixedDelay(messageSenderThread, 0, 1, TimeUnit.SECONDS);
+        scheduler.scheduleWithFixedDelay(new QueueCleaner(messageQueue), 0, 15, TimeUnit.SECONDS);
     }
 
     @Override

--- a/src/test/java/com/flipkart/foxtrot/client/EventAsyncSendTest.java
+++ b/src/test/java/com/flipkart/foxtrot/client/EventAsyncSendTest.java
@@ -47,7 +47,7 @@ public class EventAsyncSendTest {
                                         "/foxtrot/v1/document/test/bulk", eventHandler));
 
     @Test
-    public void testQueuedSend() throws Exception {
+    public void testAsyncSend() throws Exception {
 
         FoxtrotClientConfig clientConfig = new FoxtrotClientConfig();
         clientConfig.setHost(testHostPort.getHostName());

--- a/src/test/java/com/flipkart/foxtrot/client/EventQueuedSendTest.java
+++ b/src/test/java/com/flipkart/foxtrot/client/EventQueuedSendTest.java
@@ -55,7 +55,7 @@ public class EventQueuedSendTest {
         clientConfig.setHost(testHostPort.getHostName());
         clientConfig.setPort(testHostPort.getPort());
         clientConfig.setTable("test");
-        clientConfig.setLocalQueuePath(path);
+        clientConfig.setQueuePath(path);
         clientConfig.setBatchSize(50);
 
         FoxtrotClient client = new FoxtrotClient(clientConfig, new MemberSelector() {
@@ -95,7 +95,7 @@ public class EventQueuedSendTest {
         clientConfig.setHost(testHostPort.getHostName());
         clientConfig.setPort(testHostPort.getPort());
         clientConfig.setTable("test");
-        clientConfig.setLocalQueuePath(path);
+        clientConfig.setQueuePath(path);
         clientConfig.setBatchSize(50);
 
         FoxtrotClient client = new FoxtrotClient(clientConfig, new MemberSelector() {


### PR DESCRIPTION
Hardcoded interval between successive message sender thread to 1 sec. Clients need not be aware of this value.
Changed queue cleaner scheduler from fixedRate to fixedDelay. If one cleaning thread is running, there is no point starting other.